### PR TITLE
[branch/6.2] pyqt: Disable OpenGL ES2 also for aarch64

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -104,4 +104,3 @@ if [ -n "$BASEAPP_REMOVE_PYWEBENGINE" ]; then
 fi
 
 rm -rfv $(readlink -f "$0")
-

--- a/pyqt/pyqt.json
+++ b/pyqt/pyqt.json
@@ -1,12 +1,8 @@
 {
     "name": "pyqt",
     "build-options": {
-        "arch": {
-            "x86_64": {
-                "env": {
-                    "EXTRA_PYQT_CONFIG_OPTS": "--disabled-feature=PyQt_OpenGL_ES2"
-                }
-            }
+        "env": {
+            "EXTRA_PYQT_CONFIG_OPTS": "--disabled-feature=PyQt_OpenGL_ES2"
         }
     },
     "config-opts": [


### PR DESCRIPTION
Desktop OpenGL still enabled for aarch64 and OpenGL ES2 is disabled.

> $ grep 'QT_FEATURE_opengl' ${FLATPAK_SYSTEM_DIR}/runtime/org.kde.Sdk/aarch64/6.2/active/files/include/QtGui/qtgui-config.h
>     #define QT_FEATURE_opengles2 -1
>     #define QT_FEATURE_opengles3 -1
>     #define QT_FEATURE_opengles31 -1
>     #define QT_FEATURE_opengles32 -1
>     #define QT_FEATURE_opengl 1

See also https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/19#note_377966

Closes #1.