### PR TITLE
CI: Also check branch/6.2

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository_owner == 'flathub'
     strategy:
       matrix:
-        branch: [ branch/5.15-21.08 ]
+        branch: [ branch/5.15-21.08, branch/6.2 ]
     steps:
       - name: Git checkout ${{ github.repository }}.git/${{ matrix.branch }}
         uses: actions/checkout@v2


### PR DESCRIPTION
Adding branch/6.2 to the strategy matrix in the default branch update workflow.  
No application rebuild is needed.