### PR TITLE
CI: Lower publish delay

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,6 @@
 {
     "automerge-flathubbot-prs": false,
     "disable-external-data-checker": true,
+    "publish-delay-hours": 1,
     "skip-appstream-check": true
 }


### PR DESCRIPTION
Publishing builds faster is desired in a base application, as dependent applications can get fixes more quickly.

Also, publish delay should be shorter than the update workflow interval length. This can lower the chance that a pull request will be generated when the latest build has an outdated `x-base-commit`, but the app was actually built with an updated QtWebEngine base application.  
Hitting this case would be more probable if we have auto-merging enabled.  
Should be noted that this will be avoided after implementing fetching base app commit from unpublished builds (see comments in the workflow).