### PR TITLE
[branch/5.15-21.08] Cleanup: Keep python-packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ While the following Python modules are dependencies of the mentioned build tools
 `BaseApp-cleanup.sh` script, as they might be needed by the Flatpak application.
 
 * python-packaging
+* python-ply
 * python-pyparsing
-* python-tomli
 * python-toml
+* python-tomli
 
 ## How to use?
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Build tools are included to help package extra PytQt bindings and Python modules
 * python-build
 * python-flit-core
 * python-installer
-* python-packaging
 * python-pep517
 * python-setuptools-scm
 
@@ -39,6 +38,7 @@ Build tools are included to help package extra PytQt bindings and Python modules
 While the following Python modules are dependencies of the mentioned build tools, they are not removed by the  
 `BaseApp-cleanup.sh` script, as they might be needed by the Flatpak application.
 
+* python-packaging
 * python-pyparsing
 * python-tomli
 * python-toml

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -33,11 +33,6 @@ rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/installer
 rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/installer-*.dist-info
 rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/installer-*-py*.egg-info
 
-# python-packaging
-rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/packaging
-rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/packaging-*.dist-info
-rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/packaging-*-py*.egg-info
-
 # python-pep517
 rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/pep517
 rm -rfv ${FLATPAK_DEST}/lib/python*/site-packages/pep517-*.dist-info


### PR DESCRIPTION
Keep python-packaging, as its use is not limited to packaging Python modules.

Also update README.md as it's missing documented about retained python-ply module.

Closes #12.