### PR TITLE
Add missing bindings, lib/python symlink, and update modules

### DIFF
--- a/com.riverbankcomputing.PyQt.BaseApp.metainfo.xml
+++ b/com.riverbankcomputing.PyQt.BaseApp.metainfo.xml
@@ -8,6 +8,7 @@
   <url type="homepage">https://www.riverbankcomputing.com</url>
   <developer_name>Riverbank Computing Limited</developer_name>
   <releases>
+    <release version="5.15.6" date="2022-06-18"/>
     <release version="5.15.5" date="2021-10-18"/>
   </releases>
 </component>

--- a/com.riverbankcomputing.PyQt.BaseApp.yaml
+++ b/com.riverbankcomputing.PyQt.BaseApp.yaml
@@ -9,6 +9,11 @@ base: io.qt.qtwebengine.BaseApp
 base-version: 5.15-21.08
 x-base-commit: 4e9b6655ba5bf04c7370659d18033aa04df722f50976f651d6456f551b5f9876
 modules:
+  - name: lib_python
+    buildsystem: simple
+    build-commands:
+      - install -dm755 ${FLATPAK_DEST}/lib
+      - ln -s python$(python -c 'import sys; print("%s.%s" %sys.version_info[0:2])') ${FLATPAK_DEST}/lib/python
   - python-packaging-tools/python-packaging-tools.json
   - pyqt/pyqt.json
   - pyqt-webengine/pyqt-webengine.json

--- a/pyqt-webengine/pyqt-webengine.json
+++ b/pyqt-webengine/pyqt-webengine.json
@@ -22,8 +22,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://files.pythonhosted.org/packages/60/66/56e118abb4cddd8e4bea6f89bdec834069b52479fb991748f1b21950811e/PyQtWebEngine-5.15.5.tar.gz",
-            "sha256": "ab47608dccf2b5e4b950d5a3cc704b17711af035024d07a9b71ad29fc103b941",
+            "url": "https://files.pythonhosted.org/packages/cf/4b/ca01d875eff114ba5221ce9311912fbbc142b7bb4cbc4435e04f4f1f73cb/PyQtWebEngine-5.15.6.tar.gz",
+            "sha256": "ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721",
             "x-checker-data": {
                 "is-main-source": true,
                 "type": "pypi",

--- a/pyqt/configure
+++ b/pyqt/configure
@@ -9,6 +9,7 @@ else
   pyqt_bindings=(
     --enable=pylupdate
     --enable=pyrcc
+    --enable=Qt
     --enable=QtBluetooth
     --enable=QtCore
     --enable=QtDBus

--- a/pyqt/pyqt.json
+++ b/pyqt/pyqt.json
@@ -31,8 +31,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://files.pythonhosted.org/packages/3b/27/fd81188a35f37be9b3b4c2db1654d9439d1418823916fe702ac3658c9c41/PyQt5-5.15.6.tar.gz",
-            "sha256": "80343bcab95ffba619f2ed2467fd828ffeb0a251ad7225be5fc06dcc333af452",
+            "url": "https://files.pythonhosted.org/packages/e1/57/2023316578646e1adab903caab714708422f83a57f97eb34a5d13510f4e1/PyQt5-5.15.7.tar.gz",
+            "sha256": "755121a52b3a08cb07275c10ebb96576d36e320e572591db16cfdbc558101594",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "PyQt5"


### PR DESCRIPTION
Supersedes #31 

* Update PyQt5-5.15.6.tar.gz to 5.15.7
* Update PyQtWebEngine-5.15.5.tar.gz to 5.15.6
* Add lib/python symlink  
  Flatpak packaging creates extra challenges, sometime forces us to patch a module's buildsystem.  
  This symlink is useful for avoiding referring to the version specific path, and having to update the path post runtime bump in whatever workaround was used.  
  I needed this in two occasions already, so I'm adding this here.
* Add missing Qt bindings