### PR TITLE
CI: Update checkout action to v3 for setting safe directory

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -27,7 +27,7 @@ jobs:
         branch: [ branch/5.15-21.08, branch/6.2 ]
     steps:
       - name: Git checkout ${{ github.repository }}.git/${{ matrix.branch }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
 


### PR DESCRIPTION
Git 2.35.2 introduced a regression to the update workflow and require
setting the checked-out repo as safe.
Version 3 of the checkout action does exactly that.

https://github.blog/2022-04-12-git-security-vulnerability-announced/
https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else