### PR TITLE
Mark branch as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,6 +1,7 @@
 {
     "automerge-flathubbot-prs": false,
     "disable-external-data-checker": true,
+    "end-of-life": "Branch 6.2 of the PyQt base application is no longer supported. A PyQt 6 branch matching a more recent KDE runtime is available.",
     "publish-delay-hours": 1,
     "skip-appstream-check": true
 }


### PR DESCRIPTION
There are no more users in Flathub stable, see #25. Also, KDE 6.3 is still based on Freedesktop 21.08, so except for the Qt release, there are no significant changes in the runtime.