### PR TITLE
[test] Update to 5.15-22.08 runtime

### DIFF
--- a/com.riverbankcomputing.PyQt.BaseApp.yaml
+++ b/com.riverbankcomputing.PyQt.BaseApp.yaml
@@ -1,13 +1,13 @@
 app-id: com.riverbankcomputing.PyQt.BaseApp
-branch: 5.15-21.08
+branch: 5.15-22.08
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 command: QtWebEngineProcess
 separate-locales: false
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-21.08
-x-base-commit: 0aff995352070546edbf0fd169cc8ac6ebc6827b0e21e7cb458a351fc0438301
+base-version: 5.15-22.08
+x-base-commit: c2888288b5be8e8b3de0874bf62126de5ba6bda906f3cd9a494a7fffb154485d
 modules:
   - name: lib_python
     buildsystem: simple

--- a/examples/PyQtApp.yaml
+++ b/examples/PyQtApp.yaml
@@ -1,9 +1,9 @@
 app-id: org.kde.PyQtApp
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: 5.15-21.08
+base-version: 5.15-22.08
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 build-options:

--- a/examples/PyQtWebEngineApp.yaml
+++ b/examples/PyQtWebEngineApp.yaml
@@ -1,9 +1,9 @@
 app-id: org.kde.PyQtWebEngineApp
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: 5.15-21.08
+base-version: 5.15-22.08
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 modules:


### PR DESCRIPTION
Draft, as this shouldn't be merged to 5.15-21.08. A new branch should be created instead.  
Expected to fail ATM as the QtWebEngine base app branch just built, and wasn't published yet, but I might not have much time later for this, so I'm creating this now.

Due to incompatibility of the runtime FFmpeg's libs with Chromium 87, the QtWebEngine branch is now statically links FFmpeg using the in-tree sources.  
To avoid possible regressions with media playback in qutebrowser, even though I haven't noticed such, I plan to keep the 5.15-21.08 branch until the app will switch to Qt6 in the next major release.

Digressing a little bit, but I should mention here that I haven't checked yet if the FFmpeg change in the runtime will also affect QtWebEngine 6.4 (Chromium 98).  
Also, the [ZapZap](https://github.com/rafatosta/zapzap) app is on Flathub, and it's another PyQtWebEngine 6 app that is likely making use of QtWebEngine media playback feature, so we might need to ping the ZapZap maintainer when adding the 6.4 branch, and ask if there are regressions.  

Oh! I forgot to mention that except qutebrowser that will switch to PyQt 6, I don't believe there are PyQtWebEngine 5 apps on Flathub that use the media playback capability of QtWebEngine.