### PR TITLE
[21.08]Remove publish delay

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,6 +1,5 @@
 {
     "automerge-flathubbot-prs": false,
     "disable-external-data-checker": true,
-    "publish-delay-hours": 1,
     "skip-appstream-check": true
 }


### PR DESCRIPTION
For some reason the Flathub Admins didn't like this and block the build, if a App has a lower publish delay. See flathub/flatpak-builder-lint#20.