### PR TITLE
Set QTWEBENGINEPROCESS_PATH, to avoid failure

### DIFF
--- a/examples/PyQtWebEngineApp.yaml
+++ b/examples/PyQtWebEngineApp.yaml
@@ -6,6 +6,8 @@ base: com.riverbankcomputing.PyQt.BaseApp
 base-version: 5.15-22.08
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
+finish-args:
+  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
 modules:
   - name: PyQtWebEngineApp
     buildsystem: simple


### PR DESCRIPTION
Borrowed from https://github.com/flathub/io.qt.qtwebengine.BaseApp/wiki

Without this environment variable, applications fail with this message:

    Could not find QtWebEngineProcess
    Aborted