### PR TITLE
Mark 5.15-21.08 as EOL

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository_owner == 'flathub'
     strategy:
       matrix:
-        branch: [ branch/5.15-21.08, branch/5.15-22.08, branch/6.3, branch/6.4 ]
+        branch: [ branch/5.15-22.08, branch/6.3, branch/6.4 ]
     steps:
       - name: Git checkout ${{ github.repository }}.git/${{ matrix.branch }}
         uses: actions/checkout@v3

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,6 @@
 {
     "automerge-flathubbot-prs": false,
     "disable-external-data-checker": true,
-    "skip-appstream-check": true
+    "skip-appstream-check": true,
+    "end-of-life": "Branch 5.15-21.08 of the PyQt base application is no longer supported. Please use 5.15-22.08 instead."
 }


### PR DESCRIPTION
Ping @tinywrkb. Your Qutebrowser is the only one still using this Version. And the underlying [QtWebEngine BaseApp is also EOL](https://github.com/flathub/io.qt.qtwebengine.BaseApp/pull/179), so I think it's time to set this Branch EOL.