### PR TITLE
Move QTWEBENGINEPROCESS_PATH to PyQtWebEngine example

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -75,6 +75,9 @@ base: com.riverbankcomputing.PyQt.BaseApp
 base-version: '6.7'
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
+finish-args:
+  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
+  ...
 modules:
   - name: PyQtWebEngineApp
 ...
@@ -97,9 +100,6 @@ cleanup-commands:
 build-options:
   env:
     - BASEAPP_REMOVE_WEBENGINE=1
-finish-args:
-  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
-  ...
 modules:
   - name: PyQtApp
 ...


### PR DESCRIPTION
Move the finish-args to the correct module, since it's relevant for apps with PyQtWebEngine but not for applications without.